### PR TITLE
refactor: address `svelte-check` errors

### DIFF
--- a/src/lib/pickles.ts
+++ b/src/lib/pickles.ts
@@ -71,11 +71,13 @@ export default class Pixels {
 		this.width = width;
 		this.height = height;
 
-		this.gl = canvas.getContext("webgl2");
+		const gl = canvas.getContext("webgl2");
 
-		if (this.gl === null) {
+		if (gl === null) {
 			throw new TypeError("Could not get 'webgl2' context.");
 		}
+
+		this.gl = gl;
 
 		this.program = WebGL.createProgram(this.gl, source.vertex, source.fragment);
 


### PR DESCRIPTION
During the process of updating SvelteKit, I let a bunch of errors slide through (to be fair, everything does work). There is a lot to fix, but I am just glad all of TypeScript's checks actually work now. 

Anyways, we gotta get those errors down to 0! 