### PR TITLE
refactor(lib): simplify/improve texture workflow

### DIFF
--- a/src/lib/texture.ts
+++ b/src/lib/texture.ts
@@ -1,6 +1,4 @@
-import * as WebGL from "./webgl";
-
-export function createImageFromURL(url: URL): Promise<HTMLImageElement> {
+export function createImageFromURL(url: string): Promise<HTMLImageElement> {
 	return new Promise((resolve, reject) => {
 		try {
 			const image = new Image();
@@ -9,40 +7,25 @@ export function createImageFromURL(url: URL): Promise<HTMLImageElement> {
 				resolve(image);
 			};
 
-			image.src = url.toString();
+			image.src = url;
 		} catch (error) {
 			reject(error);
 		}
 	});
 }
 
-export async function createTextureFromURL(
-	url: URL,
-	gl: WebGL.RenderingContext
-): Promise<Texture2D> {
-	const image = await createImageFromURL(url);
-	const texture = WebGL.createTextureFromImage(gl, image);
-
-	return new Texture2D(image, texture);
-}
-
 export default class Texture2D {
-	public get width(): number {
-		return this.image.width;
-	}
-	public get height(): number {
-		return this.image.height;
-	}
-
-	public readonly image: HTMLImageElement;
+	public readonly width: number;
+	public readonly height: number;
 	public readonly texelWidth: number;
 	public readonly texelHeight: number;
 	public readonly texture: WebGLTexture;
 
-	constructor(image: HTMLImageElement, texture: WebGLTexture) {
-		this.image = image;
-		this.texelWidth = 1 / this.image.width;
-		this.texelHeight = 1 / this.image.height;
+	constructor(width: number, height: number, texture: WebGLTexture) {
+		this.width = width;
+		this.height = height;
+		this.texelWidth = 1 / this.width;
+		this.texelHeight = 1 / this.height;
 		this.texture = texture;
 	}
 }

--- a/src/lib/webgl.ts
+++ b/src/lib/webgl.ts
@@ -139,7 +139,7 @@ export function createTexture(
 	gl: RenderingContext,
 	width: number,
 	height: number,
-	pixels: Uint8Array
+	pixels: Uint8ClampedArray
 ) {
 	const texture = gl.createTexture();
 
@@ -160,7 +160,7 @@ export function createTexture(
 		pixels
 	);
 
-	_textureMaintenance(gl, width, height);
+	_textureMaintenance(gl);
 
 	return texture;
 }
@@ -178,28 +178,22 @@ export function createTextureFromImage(
 	gl.bindTexture(gl.TEXTURE_2D, texture);
 	gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
 
-	_textureMaintenance(gl, image.width, image.height);
+	_textureMaintenance(gl);
 
 	return texture;
 }
 
-function _isPowerOfTwo(value: number) {
-	return (value & (value - 1)) === 0;
-}
+function _textureMaintenance(gl: RenderingContext) {
+	gl.generateMipmap(gl.TEXTURE_2D);
 
-function _textureMaintenance(
-	gl: RenderingContext,
-	width: number,
-	height: number
-) {
-	if (_isPowerOfTwo(width) && _isPowerOfTwo(height)) {
-		gl.generateMipmap(gl.TEXTURE_2D);
-	} else {
-		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
-		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
-	}
+	gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+	gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+	gl.texParameteri(
+		gl.TEXTURE_2D,
+		gl.TEXTURE_MIN_FILTER,
+		gl.LINEAR_MIPMAP_LINEAR
+	);
+	gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
 }
 
 function _allocateBuffer(


### PR DESCRIPTION
The main changes are as follows:

- use `string` instead of `URL` when loading an image
- always generate mipmaps when creating `WebGLTexture`s
- `Texture2D`'s constructor no longer requires an `HTMLImageElement`